### PR TITLE
Proposal/discussion: update CV DAC outs before trigger outs?

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -320,58 +320,6 @@ void clock(u8 phase) {
 			series_step++;
 
 
-		// TRIGGER
-		triggered = 0;
-		if((rnd() % 255) < w.wp[pattern].step_probs[pos]) {
-			
-			if(w.wp[pattern].step_choice & 1<<pos) {
-				count = 0;
-				for(i1=0;i1<4;i1++)
-					if(w.wp[pattern].steps[pos] >> i1 & 1) {
-						found[count] = i1;
-						count++;
-					}
-
-				if(count == 0)
-					triggered = 0;
-				else if(count == 1)
-					triggered = 1<<found[0];
-				else
-					triggered = 1<<found[rnd()%count];
-			}	
-			else {
-				triggered = w.wp[pattern].steps[pos];
-			}
-			
-			if(w.wp[pattern].tr_mode == 0) {
-				if(triggered & 0x1 && w.tr_mute[0]) gpio_set_gpio_pin(B00);
-				if(triggered & 0x2 && w.tr_mute[1]) gpio_set_gpio_pin(B01);
-				if(triggered & 0x4 && w.tr_mute[2]) gpio_set_gpio_pin(B02);
-				if(triggered & 0x8 && w.tr_mute[3]) gpio_set_gpio_pin(B03);
-			} else {
-				if(w.tr_mute[0]) {
-					if(triggered & 0x1) gpio_set_gpio_pin(B00);
-					else gpio_clr_gpio_pin(B00);
-				}
-				if(w.tr_mute[1]) {
-					if(triggered & 0x2) gpio_set_gpio_pin(B01);
-					else gpio_clr_gpio_pin(B01);
-				}
-				if(w.tr_mute[2]) {
-					if(triggered & 0x4) gpio_set_gpio_pin(B02);
-					else gpio_clr_gpio_pin(B02);
-				}
-				if(w.tr_mute[3]) {
-					if(triggered & 0x8) gpio_set_gpio_pin(B03);
-					else gpio_clr_gpio_pin(B03);
-				}
-
-			}
-		}
-
-		monomeFrameDirty++;
-
-
 		// PARAM 0
 		if((rnd() % 255) < w.wp[pattern].cv_probs[0][pos] && w.cv_mute[0]) {
 			if(w.wp[pattern].cv_mode[0] == 0) {
@@ -430,6 +378,58 @@ void clock(u8 phase) {
 		spi_write(SPI,cv1>>4);
 		spi_write(SPI,cv1<<4);
 		spi_unselectChip(SPI,DAC_SPI);
+
+
+		// TRIGGER
+		triggered = 0;
+		if((rnd() % 255) < w.wp[pattern].step_probs[pos]) {
+			
+			if(w.wp[pattern].step_choice & 1<<pos) {
+				count = 0;
+				for(i1=0;i1<4;i1++)
+					if(w.wp[pattern].steps[pos] >> i1 & 1) {
+						found[count] = i1;
+						count++;
+					}
+
+				if(count == 0)
+					triggered = 0;
+				else if(count == 1)
+					triggered = 1<<found[0];
+				else
+					triggered = 1<<found[rnd()%count];
+			}	
+			else {
+				triggered = w.wp[pattern].steps[pos];
+			}
+			
+			if(w.wp[pattern].tr_mode == 0) {
+				if(triggered & 0x1 && w.tr_mute[0]) gpio_set_gpio_pin(B00);
+				if(triggered & 0x2 && w.tr_mute[1]) gpio_set_gpio_pin(B01);
+				if(triggered & 0x4 && w.tr_mute[2]) gpio_set_gpio_pin(B02);
+				if(triggered & 0x8 && w.tr_mute[3]) gpio_set_gpio_pin(B03);
+			} else {
+				if(w.tr_mute[0]) {
+					if(triggered & 0x1) gpio_set_gpio_pin(B00);
+					else gpio_clr_gpio_pin(B00);
+				}
+				if(w.tr_mute[1]) {
+					if(triggered & 0x2) gpio_set_gpio_pin(B01);
+					else gpio_clr_gpio_pin(B01);
+				}
+				if(w.tr_mute[2]) {
+					if(triggered & 0x4) gpio_set_gpio_pin(B02);
+					else gpio_clr_gpio_pin(B02);
+				}
+				if(w.tr_mute[3]) {
+					if(triggered & 0x8) gpio_set_gpio_pin(B03);
+					else gpio_clr_gpio_pin(B03);
+				}
+
+			}
+		}
+
+		monomeFrameDirty++;
 	}
 	else {
 		gpio_clr_gpio_pin(B10);


### PR DESCRIPTION
When patching White Whale's CV and Gate outputs directly to Mutable Instruments' Rings 1V/Oct and Strum inputs, I noticed some odd behavior; I wasn't getting the pitches I expected from the sequencer. It turns out that Rings *immediately* samples its 1V/Oct input whenever the Strum input goes high, but the pitch change from White Whale lags the gate output slightly, resulting in Rings incorrectly using the previous step's pitch value for the strummed note.

I expect this isn't a problem on analog modules or digital modules that continuously track pitch, but Mutable modules seem to contain a bit of pitch-S&H logic that locks the pitch value at gate time for a brief interval before allowing it to be bent. It seems like a reasonable expectation for downstream modules that the pitch value would be established at the rising edge of the gate.

This PR contains the changes I've been running on my WW without any issues for a few months now. The change simply moves the pitch output calculation ahead of the trigger calculation.  (Note: I just merged the upstream changes to libavr32, and haven't tested that on the hardware yet.)

This seems like a good idea for my use case, but I'm not sure what the broader consequences might be. Is there perhaps a competing desire to have the gate change as soon as possible after the clock is triggered? 

It would also possible to restructure the code to first do the calculations for both the CV and gate outputs, and then batch all the hardware updates as close together as possible. That would help a theoretical (imaginary?) user for whom this PR would create the opposite problem -- pitch changes happening too far *ahead* of the gate change .