### PR TITLE
latest libavr32, fix config.mk, use init_i2c_follower

### DIFF
--- a/src/config.mk
+++ b/src/config.mk
@@ -68,6 +68,7 @@ CSRCS = \
        ../libavr32/src/i2c.c     \
        ../libavr32/src/init_trilogy.c \
        ../libavr32/src/init_common.c \
+       ../libavr32/src/interrupts.c \
        ../libavr32/src/monome.c \
        ../libavr32/src/timers.c \
        ../libavr32/src/usb.c \
@@ -78,6 +79,7 @@ CSRCS = \
        ../libavr32/src/usb/hid/uhi_hid.c \
        ../libavr32/src/usb/midi/uhi_midi.c \
        ../libavr32/src/usb/midi/midi.c \
+       ../libavr32/src/usb/msc/msc.c \
        avr32/drivers/adc/adc.c                            \
        avr32/drivers/flashc/flashc.c                      \
        avr32/drivers/gpio/gpio.c                          \
@@ -101,7 +103,7 @@ CSRCS = \
 ASSRCS = \
        avr32/utils/startup/trampoline_uc3.S               \
        avr32/drivers/intc/exception.S                     \
-              
+
 
 # List of include paths.
 INC_PATH = \
@@ -111,6 +113,7 @@ INC_PATH = \
        ../src/usb/ftdi \
        ../src/usb/hid \
        ../src/usb/midi \
+       ../src/usb/msc \
        ../conf      \
        ../conf/trilogy \
        avr32/boards                                       \

--- a/src/main.c
+++ b/src/main.c
@@ -2050,7 +2050,7 @@ int main(void)
 	init_usb_host();
 	init_monome();
 
-	init_i2c_slave(0x10);
+	init_i2c_follower(0x10);
 
 
 	print_dbg("\r\n\n// white whale //////////////////////////////// ");


### PR DESCRIPTION
note: i changed the default branch in this repo to `main` ahead of the PR.

updates libavr32 to the latest and fixes compilation errors (in anticipation of grid-st changes). briefly tested on hardware.